### PR TITLE
feat: Add suffix support for alarm and metric names

### DIFF
--- a/src/stacks/baseNestedStack.ts
+++ b/src/stacks/baseNestedStack.ts
@@ -39,6 +39,7 @@ export default class BaseNestedStack extends cfn.NestedStack {
     const autoResolve = config.configAutoResolve(this.defaultType, metricName, localConf);
     const isEnabled = config.configIsEnabled(this.defaultType, metricName, localConf);
     const suffix = config.configAlarmSuffix(this.defaultType, metricName, localConf);
+    const fullMetricName = suffix ? `${metricName}-${suffix}` : metricName;
 
     if (!isEnabled) {
       return;
@@ -46,10 +47,11 @@ export default class BaseNestedStack extends cfn.NestedStack {
 
     const metric = new cw.Metric({
       ...getMetricConfig(this.defaultType, metricName, localConf),
+      metricName: fullMetricName,
       dimensions,
     });
 
-    const alarmName = `${localName}-${suffix || metricName}`;
+    const alarmName = `${localName}-${fullMetricName}`;
     const alarm = metric.createAlarm(this, alarmName, {
       ...getAlarmConfig(this.defaultType, metricName, localConf),
       alarmName,

--- a/src/stacks/baseNestedStack.ts
+++ b/src/stacks/baseNestedStack.ts
@@ -38,6 +38,7 @@ export default class BaseNestedStack extends cfn.NestedStack {
   ): void {
     const autoResolve = config.configAutoResolve(this.defaultType, metricName, localConf);
     const isEnabled = config.configIsEnabled(this.defaultType, metricName, localConf);
+    const suffix = config.configAlarmSuffix(this.defaultType, metricName, localConf);
 
     if (!isEnabled) {
       return;
@@ -48,7 +49,7 @@ export default class BaseNestedStack extends cfn.NestedStack {
       dimensions,
     });
 
-    const alarmName = `${localName}-${metricName}`;
+    const alarmName = `${localName}-${suffix || metricName}`;
     const alarm = metric.createAlarm(this, alarmName, {
       ...getAlarmConfig(this.defaultType, metricName, localConf),
       alarmName,

--- a/src/stacks/nestedLogGroup.ts
+++ b/src/stacks/nestedLogGroup.ts
@@ -67,13 +67,13 @@ export class NestedLogGroupAlarmsStack extends BaseNestedStack {
   ): void {
     const isEnabled = config.configIsEnabled(this.defaultType, metricFilterName, localConf);
     const suffix = config.configAlarmSuffix(this.defaultType, metricFilterName, localConf);
+    const fullMetricFilteName = suffix ? `${metricFilterName}-${suffix}` : metricFilterName;
 
     if (!isEnabled) {
       return;
     }
 
-    const name = `${groupName}-${suffix || metricFilterName}`;
-
+    const name = `${groupName}-${fullMetricFilteName}`;
     new logs.MetricFilter(this, name, {
       filterPattern: logs.FilterPattern.literal(pattern),
       logGroup: logs.LogGroup.fromLogGroupName(this, `${name}-log-group`, groupName),

--- a/src/stacks/nestedLogGroup.ts
+++ b/src/stacks/nestedLogGroup.ts
@@ -93,6 +93,7 @@ export class NestedLogGroupAlarmsStack extends BaseNestedStack {
     const autoResolve = config.configAutoResolve(this.defaultType, metricConfigName, localConf);
     const isEnabled = config.configIsEnabled(this.defaultType, metricConfigName, localConf);
     const suffix = config.configAlarmSuffix(this.defaultType, metricConfigName, localConf);
+    const fullMetricName = suffix ? `${metricName}-${suffix}` : metricName;
 
     if (!isEnabled) {
       return;
@@ -100,15 +101,15 @@ export class NestedLogGroupAlarmsStack extends BaseNestedStack {
 
     const metric = new cw.Metric({
       ...getMetricConfig(this.defaultType, metricConfigName, localConf),
-      metricName: suffix ? metricName + suffix : metricName,
+      metricName: fullMetricName,
       // unit is not defined with custom metrics,
       // so it can break the connection between the alarm and metric
       unit: undefined,
     });
 
-    const alarm = metric.createAlarm(this, `${localName}-${suffix || metricName}`, {
+    const alarm = metric.createAlarm(this, `${localName}-${fullMetricName}`, {
       ...getAlarmConfig(this.defaultType, metricConfigName, localConf),
-      alarmName: suffix ? metricName + suffix : metricName,
+      alarmName: fullMetricName,
     });
 
     this.snsStack.addAlarmActions(alarm, autoResolve);

--- a/src/stacks/nestedLogGroup.ts
+++ b/src/stacks/nestedLogGroup.ts
@@ -67,13 +67,13 @@ export class NestedLogGroupAlarmsStack extends BaseNestedStack {
   ): void {
     const isEnabled = config.configIsEnabled(this.defaultType, metricFilterName, localConf);
     const suffix = config.configAlarmSuffix(this.defaultType, metricFilterName, localConf);
-    const fullMetricFilteName = suffix ? `${metricFilterName}-${suffix}` : metricFilterName;
+    const fullMetricFilterName = suffix ? `${metricFilterName}-${suffix}` : metricFilterName;
 
     if (!isEnabled) {
       return;
     }
 
-    const name = `${groupName}-${fullMetricFilteName}`;
+    const name = `${groupName}-${fullMetricFilterName}`;
     new logs.MetricFilter(this, name, {
       filterPattern: logs.FilterPattern.literal(pattern),
       logGroup: logs.LogGroup.fromLogGroupName(this, `${name}-log-group`, groupName),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -125,6 +125,7 @@ export interface MetricFilterOptions {
 export interface ConfigMetricAlarm {
   enabled?: boolean;
   autoResolve?: boolean;
+  suffix?: string;
   alarm?: AlarmOptions;
   metric?: MetricOptions;
 }
@@ -367,6 +368,17 @@ export function configAutoResolve(
   }
 
   return configGetDefault(configType, metricName)?.autoResolve === true || local === true;
+}
+
+/**
+ * Check if metric is enabled for local or default config
+ */
+export function configAlarmSuffix(
+  configType: ConfigDefaultType,
+  metricName: string,
+  localConfig?: ConfigMetricAlarms,
+): string | undefined {
+  return localConfig?.[metricName]?.suffix || configGetDefault(configType, metricName)?.suffix
 }
 
 /**


### PR DESCRIPTION
Add suffix support for metrics and alarms

Example usage of suffix:
```yaml
custom:
  default:
    lambda:
      Errors:
        enabled: true
        autoResolve: false
        suffix: Warnings
        alarm:
          threshold: 2
          evaluationPeriods: 1
        metric:
          unit: Count
          statistics: Sum
```

With the above example lambda would be generated like this:
```
<lambda>-<metric>-<suffix>
```
So with the lambda called `example` the generated `Errors` alarm would look like this:
```
example-Errors-Warning
```