### PR TITLE
fix: Check when local value has enabled false

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -439,7 +439,10 @@ export function configGetAllEnabled<T extends ConfigMetricAlarms = ConfigMetricA
         return false;
       }
       const local = locals[key];
-      return local.enabled !== false || Object.values(local.alarm || {}).find(l => l.enabled !== false);
+      if (local.enabled === false) {
+        return Object.values(local.alarm || {}).find(l => l.enabled === true) !== undefined;
+      }
+      return Object.values(local.alarm || {}).find(l => l.enabled !== false) !== undefined;
     });
 
     // Add only if at least one value is enabled


### PR DESCRIPTION
With these changes the enabled check is done correctly:

Given example config:
```yaml
custom:
  default:
    lambda:
      Throttles:
        enabled: true
        autoResolve: false
        alarm:
          critical:
            threshold: 1
            evaluationPeriods: 1
        metric:
          period:
            minutes: 5
          statistic: Sum

lambdas:
  example:
    Throttles:
      enabled: false
```

With the v0.1.2 Throttles monitoring will still be enabled for example lambda.
With these changes mca-monitoring properly removes Throttles monitoring
