### PR TITLE
feat: [MCA-1028] Rework the stack splitting functionality

### DIFF
--- a/src/stacks/monitoring.ts
+++ b/src/stacks/monitoring.ts
@@ -14,9 +14,11 @@ import { createBillingAlertStack, NestedBillingAlertStack } from './nestedBillin
 // Generate stack with two nested stacks
 export class MonitoringStack extends cdk.Stack {
   private snsStack: NestedSNSStack;
+  private versionReportingEnabled = false;
 
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
+    this.versionReportingEnabled = this.node.tryGetContext('aws:cdk:version-reporting') === true;
 
     // Setup SNS topics and actions
     this.snsStack = createSNSStack(this);
@@ -40,14 +42,14 @@ export class MonitoringStack extends cdk.Stack {
    * Setup lambda monitoring
    */
   public addDefaultLambdaMonitoring(): NestedLambdaAlarmsStack[] {
-    return createLambdaMonitoring(this, this.snsStack);
+    return createLambdaMonitoring(this, this.snsStack, this.versionReportingEnabled);
   }
 
   /**
    * Setup dynamodb monitoring
    */
   public addDefaultDynamoDBMonitoring(): NestedTableAlarmsStack[] {
-    return createDynamoDBMonitoring(this, this.snsStack);
+    return createDynamoDBMonitoring(this, this.snsStack, this.versionReportingEnabled);
   }
 
   /**
@@ -61,42 +63,42 @@ export class MonitoringStack extends cdk.Stack {
    * Setup cluster monitoring
    */
   public addDefaultClusterMonitoring(): NestedClusterAlarmsStack[] {
-    return createClusterAlarms(this, this.snsStack);
+    return createClusterAlarms(this, this.snsStack, this.versionReportingEnabled);
   }
 
   /**
    * Setup Api Gateway monitoring
    */
   public addDefaultApiGatewayMonitoring(): NestedApiGatewayAlarmsStack[] {
-    return createApiGatewayAlarms(this, this.snsStack);
+    return createApiGatewayAlarms(this, this.snsStack, this.versionReportingEnabled);
   }
 
   /**
    * Setup Cloudfront monitoring
    */
   public addDefaultCloudFrontMonitoring(): NestedCloudFrontAlarmsStack[] {
-    return createCloudFrontAlarms(this, this.snsStack);
+    return createCloudFrontAlarms(this, this.snsStack, this.versionReportingEnabled);
   }
 
   /**
    * Setup RDS monitoring
    */
   public addDefaultRDSMonitoring(): NestedRDSAlarmsStack[] {
-    return createRDSMonitoring(this, this.snsStack);
+    return createRDSMonitoring(this, this.snsStack, this.versionReportingEnabled);
   }
 
   /**
    * Setup EKS monitoring
    */
   public addDefaultEKSMonitoring(): NestedEKSAlarmsStack[] {
-    return createEKSMonitoring(this, this.snsStack);
+    return createEKSMonitoring(this, this.snsStack, this.versionReportingEnabled);
   }
 
   /**
    * Setup Log Group monitoring
    */
   public addDefaultLogGroupMonitoring(props?: LogGroupsProps): NestedLogGroupAlarmsStack[] {
-    return createLogGroupMonitoring(this, this.snsStack, props);
+    return createLogGroupMonitoring(this, this.snsStack, props, this.versionReportingEnabled);
   }
 }
 

--- a/src/stacks/nestedApiGateway.ts
+++ b/src/stacks/nestedApiGateway.ts
@@ -43,8 +43,8 @@ export class NestedApiGatewayAlarmsStack extends BaseNestedStack {
   }
 }
 
-export function createApiGatewayAlarms(stack: cdk.Stack, snsStack: NestedSNSStack): NestedApiGatewayAlarmsStack[] {
-  return config.chunkByStackLimit(localType, apiGatewayMetrics).map((stackGateways, index) => {
+export function createApiGatewayAlarms(stack: cdk.Stack, snsStack: NestedSNSStack, versionReportingEnabled = true): NestedApiGatewayAlarmsStack[] {
+  return config.chunkByStackLimit(localType, apiGatewayMetrics, 0, versionReportingEnabled).map((stackGateways, index) => {
     return new NestedApiGatewayAlarmsStack(
       stack,
       stack.stackName + '-api-gateway-alarms-' + (index + 1),

--- a/src/stacks/nestedCloudFront.ts
+++ b/src/stacks/nestedCloudFront.ts
@@ -50,8 +50,8 @@ export class NestedCloudFrontAlarmsStack extends BaseNestedStack {
   }
 }
 
-export function createCloudFrontAlarms(stack: cdk.Stack, snsStack: NestedSNSStack): NestedCloudFrontAlarmsStack[] {
-  return config.chunkByStackLimit(localType, cloudFrontMetrics).map((stackDistributions, index) => {
+export function createCloudFrontAlarms(stack: cdk.Stack, snsStack: NestedSNSStack, versionReportingEnabled = true): NestedCloudFrontAlarmsStack[] {
+  return config.chunkByStackLimit(localType, cloudFrontMetrics, 0, versionReportingEnabled).map((stackDistributions, index) => {
     return new NestedCloudFrontAlarmsStack(
       stack,
       stack.stackName + '-cloudfront-alarms-' + (index + 1),

--- a/src/stacks/nestedECS.ts
+++ b/src/stacks/nestedECS.ts
@@ -4,7 +4,6 @@ import * as cfn from '@aws-cdk/aws-cloudformation';
 import BaseNestedStack from './baseNestedStack';
 import { NestedSNSStack } from './nestedSns';
 import * as config from '../utils/config';
-import { chunk } from '../utils/utils';
 
 export const clusterMetrics = [
   'CPUReservation',
@@ -43,24 +42,12 @@ export class NestedClusterAlarmsStack extends BaseNestedStack {
 }
 
 export function createClusterAlarms(stack: cdk.Stack, snsStack: NestedSNSStack): NestedClusterAlarmsStack[] {
-  const clusters = config.configGetAllEnabled(localType, clusterMetrics);
-  const keys = Object.keys(clusters);
-
-  if (keys.length === 0) {
-    return [];
-  }
-
-  if (keys.length > 30) {
-    return chunk(keys, 30).map((keys, index) => {
-      const clusters = config.configGetSelected(localType, keys);
-      return new NestedClusterAlarmsStack(
-        stack,
-        stack.stackName + '-cluster-alarms-' + (index + 1),
-        snsStack,
-        clusters,
-      );
-    });
-  }
-
-  return [new NestedClusterAlarmsStack(stack, stack.stackName + '-cluster-alarms', snsStack, clusters)];
+  return config.chunkByStackLimit(localType, clusterMetrics).map((stackClusters, index) => {
+    return new NestedClusterAlarmsStack(
+      stack,
+      stack.stackName + '-cluster-alarms-' + (index + 1),
+      snsStack,
+      stackClusters,
+    );
+  });
 }

--- a/src/stacks/nestedECS.ts
+++ b/src/stacks/nestedECS.ts
@@ -41,8 +41,8 @@ export class NestedClusterAlarmsStack extends BaseNestedStack {
   }
 }
 
-export function createClusterAlarms(stack: cdk.Stack, snsStack: NestedSNSStack): NestedClusterAlarmsStack[] {
-  return config.chunkByStackLimit(localType, clusterMetrics).map((stackClusters, index) => {
+export function createClusterAlarms(stack: cdk.Stack, snsStack: NestedSNSStack, versionReportingEnabled = true): NestedClusterAlarmsStack[] {
+  return config.chunkByStackLimit(localType, clusterMetrics, 0, versionReportingEnabled).map((stackClusters, index) => {
     return new NestedClusterAlarmsStack(
       stack,
       stack.stackName + '-cluster-alarms-' + (index + 1),

--- a/src/stacks/nestedEKS.ts
+++ b/src/stacks/nestedEKS.ts
@@ -64,8 +64,8 @@ export class NestedEKSAlarmsStack extends BaseNestedStack {
 }
 
 // Setup eks alarms
-export function createEKSMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack): NestedEKSAlarmsStack[] {
-  return config.chunkByStackLimit(localType, eksMetrics).map((stackClusters, index) => {
+export function createEKSMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack, versionReportingEnabled = true): NestedEKSAlarmsStack[] {
+  return config.chunkByStackLimit(localType, eksMetrics, 0, versionReportingEnabled).map((stackClusters, index) => {
     return new NestedEKSAlarmsStack(
       stack,
       stack.stackName + '-eks-cluster-alarms-' + (index + 1),

--- a/src/stacks/nestedEKS.ts
+++ b/src/stacks/nestedEKS.ts
@@ -4,7 +4,6 @@ import * as cfn from '@aws-cdk/aws-cloudformation';
 import BaseNestedStack from './baseNestedStack';
 import { NestedSNSStack } from './nestedSns';
 import * as config from '../utils/config';
-import { chunk } from '../utils/utils';
 
 // https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-metrics-EKS.html
 export const eksMetrics = [
@@ -66,27 +65,12 @@ export class NestedEKSAlarmsStack extends BaseNestedStack {
 
 // Setup eks alarms
 export function createEKSMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack): NestedEKSAlarmsStack[] {
-  const clusters = config.configGetAllEnabled(localType, eksMetrics);
-  const clusterKeys: string[] = Object.keys(clusters);
-
-  // Nothing to create
-  if (clusterKeys.length === 0) {
-    return [];
-  }
-
-  // Split over 8 clusters to multiple stacks
-  if (clusterKeys.length > 8) {
-    return chunk(clusterKeys, 8).map((keys, index) => {
-      const stackClusters = config.configGetSelected(localType, keys);
-      return new NestedEKSAlarmsStack(
-        stack,
-        stack.stackName + '-eks-cluster-alarms-' + (index + 1),
-        snsStack,
-        stackClusters,
-      );
-    });
-  }
-
-  // Create single stack
-  return [new NestedEKSAlarmsStack(stack, stack.stackName + '-eks-cluster-alarms', snsStack, clusters)];
+  return config.chunkByStackLimit(localType, eksMetrics).map((stackClusters, index) => {
+    return new NestedEKSAlarmsStack(
+      stack,
+      stack.stackName + '-eks-cluster-alarms-' + (index + 1),
+      snsStack,
+      stackClusters,
+    );
+  });
 }

--- a/src/stacks/nestedLambda.ts
+++ b/src/stacks/nestedLambda.ts
@@ -52,8 +52,8 @@ export class NestedLambdaAlarmsStack extends BaseNestedStack {
 }
 
 // Setup lambda alarms
-export function createLambdaMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack): NestedLambdaAlarmsStack[] {
-  return config.chunkByStackLimit(localType, lambdaMetrics).map((stackLambdas, index) => {
+export function createLambdaMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack, versionReportingEnabled = true): NestedLambdaAlarmsStack[] {
+  return config.chunkByStackLimit(localType, lambdaMetrics, 0, versionReportingEnabled).map((stackLambdas, index) => {
     return new NestedLambdaAlarmsStack(
       stack,
       stack.stackName + '-lambda-alarms-' + (index + 1),

--- a/src/stacks/nestedLogGroup.ts
+++ b/src/stacks/nestedLogGroup.ts
@@ -117,8 +117,9 @@ export function createLogGroupMonitoring(
   stack: cdk.Stack,
   snsStack: NestedSNSStack,
   props?: LogGroupsProps,
+  versionReportingEnabled = true
 ): NestedLogGroupAlarmsStack[] {
-  return config.chunkByStackLimit(localType, undefined, 1).map((stackLogGroups, index) => {
+  return config.chunkByStackLimit(localType, undefined, 1, versionReportingEnabled).map((stackLogGroups, index) => {
     return new NestedLogGroupAlarmsStack(
       stack,
       stack.stackName + '-log-group-alarms-' + (index + 1),

--- a/src/stacks/nestedRDS.ts
+++ b/src/stacks/nestedRDS.ts
@@ -64,8 +64,8 @@ export class NestedRDSAlarmsStack extends BaseNestedStack {
 }
 
 // Setup rds alarms
-export function createRDSMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack): NestedRDSAlarmsStack[] {
-  return config.chunkByStackLimit(localType, rdsMetrics).map((stackInstances, index) => {
+export function createRDSMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack, versionReportingEnabled = true): NestedRDSAlarmsStack[] {
+  return config.chunkByStackLimit(localType, rdsMetrics, 0, versionReportingEnabled).map((stackInstances, index) => {
     return new NestedRDSAlarmsStack(
       stack,
       stack.stackName + '-rds-instance-alarms-' + (index + 1),

--- a/src/stacks/nestedTable.ts
+++ b/src/stacks/nestedTable.ts
@@ -60,8 +60,8 @@ export class NestedTableAlarmsStack extends BaseNestedStack {
 }
 
 // Setup table alarms
-export function createDynamoDBMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack): NestedTableAlarmsStack[] {
-  return config.chunkByStackLimit(localType, tableMetrics).map((stackTables, index) => {
+export function createDynamoDBMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack, versionReportingEnabled = true): NestedTableAlarmsStack[] {
+  return config.chunkByStackLimit(localType, tableMetrics, 0, versionReportingEnabled).map((stackTables, index) => {
     return new NestedTableAlarmsStack(
       stack,
       stack.stackName + '-table-alarms-' + (index + 1),

--- a/src/stacks/nestedTable.ts
+++ b/src/stacks/nestedTable.ts
@@ -4,7 +4,6 @@ import * as cfn from '@aws-cdk/aws-cloudformation';
 import BaseNestedStack from './baseNestedStack';
 import { NestedSNSStack } from './nestedSns';
 import * as config from '../utils/config';
-import { chunk } from '../utils/utils';
 
 // From https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html
 export const tableMetrics = [
@@ -62,22 +61,12 @@ export class NestedTableAlarmsStack extends BaseNestedStack {
 
 // Setup table alarms
 export function createDynamoDBMonitoring(stack: cdk.Stack, snsStack: NestedSNSStack): NestedTableAlarmsStack[] {
-  const tables = config.configGetAllEnabled(localType, tableMetrics);
-  const tableKeys: string[] = Object.keys(tables);
-
-  // Nothing to create
-  if (tableKeys.length === 0) {
-    return [];
-  }
-
-  // Split over 30 tables to multiple stacks
-  if (tableKeys.length > 30) {
-    return chunk(tableKeys, 30).map((tableKeys, index) => {
-      const stackTables = config.configGetSelected(localType, tableKeys);
-      return new NestedTableAlarmsStack(stack, stack.stackName + '-table-alarms-' + (index + 1), snsStack, stackTables);
-    });
-  }
-
-  // Create single stack
-  return [new NestedTableAlarmsStack(stack, stack.stackName + '-table-alarms', snsStack, tables)];
+  return config.chunkByStackLimit(localType, tableMetrics).map((stackTables, index) => {
+    return new NestedTableAlarmsStack(
+      stack,
+      stack.stackName + '-table-alarms-' + (index + 1),
+      snsStack,
+      stackTables,
+    );
+  });
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -462,7 +462,7 @@ export function configGetAllEnabled<T extends ConfigMetricAlarms = ConfigMetricA
         [key]: {
           ...local,
           alarms: Object.entries(local.alarm || {}).reduce((acc, [topic, alarm]) => {
-            if ((local.enabled === false && alarm.enabled === true) || alarm.enabled !== false) {
+            if ((local.enabled === false && alarm.enabled === true) || (local.enabled !== false && alarm.enabled !== false)) {
               return {
                 ...acc,
                 [topic]: alarm,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -493,7 +493,6 @@ export function calculateResources<T extends ConfigMetricAlarms = ConfigMetricAl
   addPerResource = 0,
 ): { [key: string]: [number, T] } {
   const enabled = configGetAllEnabled<T>(confType, allowedMetrics);
-  const metricCount = 1;
 
   const acc: { [key: string]: [number, T] } = {};
   for (const [key, metrics] of Object.entries(enabled)) {
@@ -501,7 +500,7 @@ export function calculateResources<T extends ConfigMetricAlarms = ConfigMetricAl
       const [currentCount, currentLocals] = acc[key] || [0, {}]
 
       const alarmCount = Object.values(local.alarm || {}).length;
-      acc[key] = [currentCount + alarmCount + metricCount + addPerResource, {
+      acc[key] = [currentCount + alarmCount + addPerResource, {
         ...currentLocals,
         [metric]: local
       }];

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -439,34 +439,108 @@ export function configAutoResolve(
  */
 export function configGetAllEnabled<T extends ConfigMetricAlarms = ConfigMetricAlarms>(
   confType: ConfigLocalType,
-  metrics: string[],
+  metrics?: string[],
 ): ConfigLocals<T> {
   const all = configGetAll(confType);
 
-  return Object.keys(all).reduce((acc, key) => {
-    const locals = all[key];
-
-    if (!locals) {
+  return Object.entries(all).reduce((acc, [key, allLocals]) => {
+    if (!allLocals) {
       return acc;
     }
 
-    const isEnabled = Object.keys(locals).find(key => {
-      if (!metrics.includes(key)) {
-        return false;
+    const locals = Object.entries(allLocals).reduce((acc, [key, local]) => {
+      if (metrics && !metrics.includes(key)) {
+        return acc;
       }
-      const local = locals[key];
-      if (local.enabled === false) {
-        return Object.values(local.alarm || {}).find(l => l.enabled === true) !== undefined;
-      }
-      return Object.values(local.alarm || {}).find(l => l.enabled !== false) !== undefined;
-    });
 
-    // Add only if at least one value is enabled
-    if (isEnabled) {
-      return { ...acc, [key]: locals };
-    }
+      if (!configIsEnabled(local)) {
+        return acc;
+      }
+
+      return {
+        ...acc,
+        [key]: {
+          ...local,
+          alarms: Object.entries(local.alarm || {}).reduce((acc, [topic, alarm]) => {
+            if ((local.enabled === false && alarm.enabled === true) || alarm.enabled !== false) {
+              return {
+                ...acc,
+                [topic]: alarm,
+              };
+            }
+
+            return acc;
+          }, {} as TopicMap<AlarmOptions>),
+        }
+      }
+    }, {} as T);
 
     // Skip adding as none was enabled
-    return acc;
+    if (Object.keys(locals).length === 0) {
+      return acc;
+    }
+
+    return { ...acc, [key]: locals };
   }, {});
+}
+
+/**
+ * Calculate how many resources each metric alarm (example lambda) takes
+ */
+export function calculateResources<T extends ConfigMetricAlarms = ConfigMetricAlarms>(
+  confType: ConfigLocalType,
+  allowedMetrics?: string[],
+  addPerResource = 0,
+): { [key: string]: [number, T] } {
+  const enabled = configGetAllEnabled<T>(confType, allowedMetrics);
+  const metricCount = 1;
+
+  const acc: { [key: string]: [number, T] } = {};
+  for (const [key, metrics] of Object.entries(enabled)) {
+    for (const [metric, local] of Object.entries(metrics)) {
+      const [currentCount, currentLocals] = acc[key] || [0, {}]
+
+      const alarmCount = Object.values(local.alarm || {}).length;
+      acc[key] = [currentCount + alarmCount + metricCount + addPerResource, {
+        ...currentLocals,
+        [metric]: local
+      }];
+    }
+  }
+
+  return acc;
+}
+
+/**
+ * Generate chunked array of the metric alarms
+ */
+export function chunkByStackLimit<T extends ConfigMetricAlarms = ConfigMetricAlarms>(
+  confType: ConfigLocalType,
+  allowedMetrics?: string[],
+  addedPerResource = 0,
+): ConfigLocals<T>[] {
+  // Calculate before chunking
+  const results = calculateResources<T>(confType, allowedMetrics, addedPerResource);
+
+  const acc: ConfigLocals<T>[] = []
+  let currentCount = 0;
+  let index = 0;
+  for (const [key, [count, metrics]] of Object.entries(results)) {
+    if ((currentCount + count) > 500) {
+        // Move to next chunk and reset current count
+        index++;
+        currentCount = count;
+      } else {
+        // Increase current count
+        currentCount = currentCount + count;
+      }
+
+      if (!acc[index]) {
+        acc[index] = {};
+      }
+
+      acc[index][key] = metrics;
+  }
+
+  return acc;
 }

--- a/test/utils/config.spec.ts
+++ b/test/utils/config.spec.ts
@@ -192,7 +192,7 @@ test('find only enabled lambdas', t => {
 
 test('calculate resources', t => {
   const res = config.calculateResources(config.ConfigLocalType.Lambda, lambdaMetrics);
-  t.is(res['lambda-1'][0], 2);
+  t.is(res['lambda-1'][0], 1);
   t.not(res['lambda-1'][1]['Errors'], undefined);
 });
 

--- a/test/utils/config.spec.ts
+++ b/test/utils/config.spec.ts
@@ -189,3 +189,15 @@ test('find only enabled lambdas', t => {
   const enabled = config.configGetAllEnabled(config.ConfigLocalType.Lambda, lambdaMetrics);
   t.is(Object.keys(enabled).length, 1);
 });
+
+test('calculate resources', t => {
+  const res = config.calculateResources(config.ConfigLocalType.Lambda, lambdaMetrics);
+  t.is(res['lambda-1'][0], 2);
+  t.not(res['lambda-1'][1]['Errors'], undefined);
+});
+
+test('chuck by stack limit', t => {
+  const res = config.chunkByStackLimit(config.ConfigLocalType.Lambda, lambdaMetrics);
+  t.is(res.length, 1);
+  t.not(res[0]['lambda-1'], undefined);
+});

--- a/test/utils/config.spec.ts
+++ b/test/utils/config.spec.ts
@@ -190,8 +190,8 @@ test('find only enabled lambdas', t => {
   t.is(Object.keys(enabled).length, 1);
 });
 
-test('calculate resources', t => {
-  const res = config.calculateResources(config.ConfigLocalType.Lambda, lambdaMetrics);
+test('get resource count map', t => {
+  const res = config.getResourceCountMap(config.ConfigLocalType.Lambda, lambdaMetrics);
   t.is(res['lambda-1'][0], 1);
   t.not(res['lambda-1'][1]['Errors'], undefined);
 });


### PR DESCRIPTION
BREAKING CHANGE: New splitting is not backwards compatible

With the splitting changes the way substacks are created is
changed. This means to deploy this version of monitoring
old monitoring stack will need to be removed first